### PR TITLE
Add support for parameter attribute usage on autocompletes

### DIFF
--- a/Limbo.Console.Abstractions/AutoCompleteAttribute.cs
+++ b/Limbo.Console.Abstractions/AutoCompleteAttribute.cs
@@ -8,7 +8,7 @@ namespace Limbo.Console.Sharp
     /// <remarks>
     /// Placed on the ConsoleCommand function
     /// </remarks>
-    [AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
+    [AttributeUsage(AttributeTargets.Method | AttributeTargets.Parameter, AllowMultiple = true)]
     public sealed class AutoCompleteAttribute : Attribute {
         
         /// <summary>

--- a/Limbo.Console.Generator/AutoCompletion/AutoCompletes.cs
+++ b/Limbo.Console.Generator/AutoCompletion/AutoCompletes.cs
@@ -18,11 +18,29 @@ namespace Limbo.Console.Generator.AutoCompletion
         /// <returns></returns>
         internal static IEnumerable<AutoCompleteDefinition> Parse(IMethodSymbol methodSymbol)
         {
-            var autoCompletes = methodSymbol.GetAttributes()
+            var methodAutoCompletes = methodSymbol.GetAttributes()
                                             .Where(attr => attr.AttributeClass?.Name == nameof(AutoCompleteAttribute))
-                                            .Select(AsAutoCompleteDefinition)
+                                            .Select(attr => AsAutoCompleteDefinition(attr, null))
                                             .ToArray();
+            // Parameter-level attributes
+            var parameterAutoCompletes = methodSymbol.Parameters
+                .SelectMany((param, index) =>
+                    param.GetAttributes()
+                        .Where(attr => attr.AttributeClass?.Name == nameof(AutoCompleteAttribute))
+                        .Select(attr => AsAutoCompleteDefinition(attr, index))
+                ).ToArray();
 
+            List<AutoCompleteDefinition> autoCompletes = new List<AutoCompleteDefinition>();
+            // TODO: Use context.ReportDiagnoistic to report this to a user as an error
+            if (methodAutoCompletes.Length > 0 && parameterAutoCompletes.Length > 0)                 
+                throw new System.Exception("Cannot mix method-level and parameter-level AutoComplete attributes on the same method.");            
+            else if (methodAutoCompletes.Length > 0)
+                autoCompletes = new List<AutoCompleteDefinition>(methodAutoCompletes);
+            else if (parameterAutoCompletes.Length > 0)
+                autoCompletes = new List<AutoCompleteDefinition>(parameterAutoCompletes);
+
+
+            // TODO: Add validator that parameter and method syntax cannot be mixed (OR support it -- a little complex to support)
             ValidateAutoCompletes(methodSymbol, autoCompletes);
 
             return autoCompletes;
@@ -47,11 +65,14 @@ namespace Limbo.Console.Generator.AutoCompletion
             }
         }
 
-        private static AutoCompleteDefinition AsAutoCompleteDefinition(AttributeData attr)
+        private static AutoCompleteDefinition AsAutoCompleteDefinition(AttributeData attr, int? index = null)
         {
+            // Add warning for auto complete attributes that are on a parameter but not on a ConsoleCommand method
+            // Add warning for auto complete attributes that are on a parameter and use the index value (it will be ignored)
             var sourceMethod = attr.ConstructorArguments[0].Value as string ?? string.Empty;
             var argIndex = attr.ConstructorArguments.Length > 1 ? (int)(attr.ConstructorArguments[1].Value ?? 0) : 0;
-
+            if (index != null)
+                argIndex = index.Value;
             return new AutoCompleteDefinition(sourceMethod, argIndex);
         }
     }

--- a/Limbo.Console.Generator/ConsoleCommandGenerator.cs
+++ b/Limbo.Console.Generator/ConsoleCommandGenerator.cs
@@ -44,10 +44,8 @@ namespace Limbo.Console.Sharp.Generator
         {
             var methodSyntax = (MethodDeclarationSyntax)context.Node;
             var methodSymbol = context.SemanticModel.GetDeclaredSymbol(methodSyntax) as IMethodSymbol;
-            if (methodSymbol is null || !methodSymbol.GetAttributes().Any(attr => attr.AttributeClass?.Name == nameof(ConsoleCommandAttribute)))
-            {
-                return null;
-            }
+            if (methodSymbol is null || !methodSymbol.GetAttributes().Any(attr => attr.AttributeClass?.Name == nameof(ConsoleCommandAttribute)))            
+                return null;            
 
             var attrData = methodSymbol.GetAttributes().First(attr => attr.AttributeClass?.Name == nameof(ConsoleCommandAttribute));
             var args = attrData.ConstructorArguments;

--- a/demo/Demo.cs
+++ b/demo/Demo.cs
@@ -49,9 +49,28 @@ public partial class Demo : Node2D
         LimboConsole.Info("AttributeCommandWithArg executed with arg: " + arg1);
     }
 
+    [ConsoleCommand]
+    public void ColorsAndNumbers([AutoComplete(nameof(Numbers))] int numbers, [AutoComplete(nameof(Colors))] string colors)
+    {
+        LimboConsole.Info("ColorsAndNumbers command executed with number: " + numbers);
+        LimboConsole.Info("ColorsAndNumbers command executed with color: " + colors);
+    }
+
+    [ConsoleCommand]
+    public void SecondParameterAutoCompleted(int numbers, [AutoComplete(nameof(Colors))] string colors)
+    {
+        LimboConsole.Info("ColorsAndNumbers command executed with number: " + numbers);
+        LimboConsole.Info("ColorsAndNumbers command executed with color: " + colors);
+    }
+
     public string[] Colors()
     {
         return new[] { "red", "green", "blue" };
+    }
+
+    public int[] Numbers()
+    {
+        return new[] { 1, 2, 3, 4, 5 };
     }
 
     /// <summary>


### PR DESCRIPTION
Adds support for parameter attribute usage on autocompletes


Allows for registration of autocomplete via parameters:

```cs
    [ConsoleCommand]
    public void ColorsAndNumbers([AutoComplete(nameof(Numbers))] int numbers, [AutoComplete(nameof(Colors))] string colors)
    {
        LimboConsole.Info("ColorsAndNumbers command executed with number: " + numbers);
        LimboConsole.Info("ColorsAndNumbers command executed with color: " + colors);
    }

    [ConsoleCommand]
    public void SecondParameterAutoCompleted(int numbers, [AutoComplete(nameof(Colors))] string colors)
    {
        LimboConsole.Info("ColorsAndNumbers command executed with number: " + numbers);
        LimboConsole.Info("ColorsAndNumbers command executed with color: " + colors);
    }
```

Still can be used this way as well:

```cs
    [ConsoleCommand(description: "A command registered via attributes using source gen!")]
    [AutoComplete(nameof(Colors))]
    public void AttributeConsoleCommandWithArg(string arg1)
    {
        LimboConsole.Info("AttributeCommandWithArg executed with arg: " + arg1);
    }
 ```
   However you cannot mix the syntax